### PR TITLE
Improve GOP detection and preload option handling

### DIFF
--- a/clickpoints/includes/Database.py
+++ b/clickpoints/includes/Database.py
@@ -892,6 +892,34 @@ class DataFileExtended(DataFile):
                 if not keys and "codec" in md:
                     # no real data; keep default
                     pass
+                if not keys:
+                    # try to use ffprobe to gather keyframe information
+                    import subprocess, json
+                    try:
+                        cmd = [
+                            "ffprobe",
+                            "-v",
+                            "error",
+                            "-select_streams",
+                            "v:0",
+                            "-show_entries",
+                            "frame=pict_type",
+                            "-of",
+                            "json",
+                            fn,
+                        ]
+                        result = subprocess.run(
+                            cmd, capture_output=True, text=True, check=True
+                        )
+                        data = json.loads(result.stdout)
+                        frames = data.get("frames", [])
+                        for i, fr in enumerate(frames):
+                            if fr.get("pict_type") == "I":
+                                keys.append(i)
+                        if len(keys) >= 2:
+                            gop_size = min(b - a for a, b in zip(keys, keys[1:]))
+                    except Exception:
+                        pass
                 if keys:
                     # derive variable GOP, but we still preload full blocks around current
                     pass

--- a/clickpoints/modules/OptionEditor.py
+++ b/clickpoints/modules/OptionEditor.py
@@ -301,7 +301,14 @@ class OptionEditorWindow(QtWidgets.QWidget):
                 if option.hidden:
                     continue
                 edit = getOptionInputWidget(option, self.layout)
-                edit.valueChanged.connect(lambda value, edit=edit, option=option: self.Changed(edit, value, option))
+                if option.key in {"bidirectional_preloading", "preload_mode"}:
+                    edit.valueChanged.connect(
+                        lambda value, edit=edit, option=option: self._preload_option_changed(edit, value, option)
+                    )
+                else:
+                    edit.valueChanged.connect(
+                        lambda value, edit=edit, option=option: self.Changed(edit, value, option)
+                    )
                 edit.current_value = None
                 edit.option = option
                 edit.error = None
@@ -492,10 +499,12 @@ class OptionEditorWindow(QtWidgets.QWidget):
         if option.key == "buffer_mode":
             self.edits_by_name["buffer_size"].setDisabled(value != 1)
             self.edits_by_name["buffer_memory"].setDisabled(value != 2)
-        if option.key in {"bidirectional_preloading", "preload_mode"}:
-            self._update_preload_widgets()
         field.current_value = value
         self.button_apply.setDisabled(False)
+
+    def _preload_option_changed(self, field: QtWidgets.QWidget, value: Any, option: Option) -> None:
+        self.Changed(field, value, option)
+        self._update_preload_widgets()
 
     def Apply(self) -> bool:
         for edit in self.edits:
@@ -511,6 +520,7 @@ class OptionEditorWindow(QtWidgets.QWidget):
         self.data_file.optionsChanged(None)
         BroadCastEvent(self.window.modules, "optionsChanged", None)
         self.window.JumpFrames(0)
+        self._update_preload_widgets()
         return True
 
     def Ok(self) -> None:


### PR DESCRIPTION
## Summary
- use ffprobe to derive keyframe positions when imageio lacks GOP info
- update option editor to enable mode selection immediately after toggling bidirectional preloading and refresh related widgets when changing mode

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689793021170832e941fc526d724dd63