### PR TITLE
Simplify video preloading with manual GOP size

### DIFF
--- a/clickpoints/Core.py
+++ b/clickpoints/Core.py
@@ -380,13 +380,14 @@ class ClickPointsWindow(QtWidgets.QWidget):
         if opts.bidirectional_preloading:
             mode = opts.preload_mode
             gops = opts.preload_gops
+            gop_size = opts.preload_gop_size
             frame_buf = opts.preload_frame_buffer
             batch = opts.preload_batch_size
             # schedule quickly so UI isn't blocked
             QtCore.QTimer.singleShot(
                 0,
-                lambda m=mode, g=gops, f=frame_buf, b=batch, idx=target_id, layer=layer_id:
-                    self.data_file.preload_bidirectional(idx, layer, m, g, f, b)
+                lambda m=mode, g=gops, s=gop_size, f=frame_buf, b=batch, idx=target_id, layer=layer_id:
+                    self.data_file.preload_bidirectional(idx, layer, m, g, s, f, b)
             )
 
 

--- a/clickpoints/DataFile.py
+++ b/clickpoints/DataFile.py
@@ -1630,6 +1630,14 @@ class DataFile:
             tooltip="Number of GOPs to preload before and after the current one in video mode.",
         )
         self._AddOption(
+            key="preload_gop_size",
+            display_name="GOP Size",
+            default=30,
+            value_type="int",
+            min_value=1,
+            tooltip="Frames per GOP for video preloading. Performance improves drastically if this matches the actual GOP size. Multiple videos with different GOP sizes are not yet supported.",
+        )
+        self._AddOption(
             key="preload_frame_buffer",
             display_name="Buffered Frames",
             default=70,

--- a/clickpoints/includes/Database.py
+++ b/clickpoints/includes/Database.py
@@ -870,72 +870,25 @@ class DataFileExtended(DataFile):
         fn = image_obj.filename.lower()
         return fn.endswith((".mp4", ".mov", ".avi", ".mkv", ".webm"))
 
-    def _get_gop_bounds(self, frame_index: int, image_obj, default_gop: int) -> Tuple[int, int]:
-        """
-        Return (start, end) indices (inclusive) of the GOP containing frame_index.
-        Try to detect keyframes via imageio metadata; fallback to default_gop.
-        """
-        # simple cache on the DataFileExtended instance
-        if not hasattr(self, "_gop_cache"):
-            self._gop_cache = {}  # {filename: {"keys":[...], "gop_size":int}}
+    def _get_gop_bounds(self, frame_index: int, gop_size: int) -> Tuple[int, int]:
+        """Return (start, end) indices of the GOP containing ``frame_index``."""
+        start = (frame_index // gop_size) * gop_size
+        end = min(start + gop_size - 1, self.get_image_count() - 1)
+        return start, end
 
-        fn = image_obj.get_full_filename()
-        cache = self._gop_cache.get(fn)
-        if cache is None:
-            keys = []
-            gop_size = default_gop
-            try:
-                rdr = imageio.get_reader(fn)
-                md = rdr.get_meta_data()
-                # some backends expose 'key_frames'
-                keys = md.get("key_frames", []) or md.get("keyframes", [])
-                if not keys and "codec" in md:
-                    # no real data; keep default
-                    pass
-                if keys:
-                    # derive variable GOP, but we still preload full blocks around current
-                    pass
-            except Exception:
-                pass
-            cache = {"keys": keys, "gop_size": gop_size}
-            self._gop_cache[fn] = cache
-
-        keys = cache["keys"]
-        gop_size = cache["gop_size"]
-
-        if keys:
-            # find last key <= frame_index
-            import bisect
-            i = bisect.bisect_right(keys, frame_index) - 1
-            start = keys[i] if i >= 0 else 0
-            # next key - 1 or end of video
-            end = keys[i + 1] - 1 if i + 1 < len(keys) else self.get_image_count() - 1
-            return start, end
-        else:
-            # fixed-size GOP fallback
-            start = (frame_index // gop_size) * gop_size
-            end = min(start + gop_size - 1, self.get_image_count() - 1)
-            return start, end
-
-    def has_gop_info(self, image_obj=None) -> bool:
-        """Return True if we detected GOP/keyframe information for the image."""
+    def is_video(self, image_obj=None) -> bool:
+        """Return True if the underlying data source is a video."""
         try:
             if image_obj is None:
                 if self.current_image_index is None or self.current_layer is None:
                     return False
                 image_obj = self.table_image.get(sort_index=self.current_image_index, layer_id=self.current_layer.id)
-            fn = image_obj.get_full_filename()
-            cache = getattr(self, "_gop_cache", {}).get(fn)
-            if cache is None:
-                # trigger cache generation
-                self._get_gop_bounds(0, image_obj, 0)
-                cache = self._gop_cache.get(fn)
-            return bool(cache.get("keys"))
+            return self._is_video_image(image_obj)
         except Exception:
             return False
 
     def preload_bidirectional(self, center: int, layer, mode: int, gop_count: int,
-                              frame_buffer: int, batch_size: int):
+                              gop_size: int, frame_buffer: int, batch_size: int):
         """Preload frames around ``center`` according to the selected mode.
 
         Parameters
@@ -960,10 +913,10 @@ class DataFileExtended(DataFile):
         if mode == 0:
             # video mode: preload whole GOPs
             img = self.table_image.get(sort_index=center, layer_id=layer.id)
-            if not (self._is_video_image(img) and self.has_gop_info(img)):
+            if not self._is_video_image(img):
                 return
             ranges = []
-            start, end = self._get_gop_bounds(center, img, 0)
+            start, end = self._get_gop_bounds(center, gop_size)
             ranges.append((start, end))
 
             # walk backwards and forwards across video boundaries
@@ -971,8 +924,7 @@ class DataFileExtended(DataFile):
             for _ in range(gop_count):
                 if prev_end < 0:
                     break
-                prev_img = self.table_image.get(sort_index=prev_end, layer_id=layer.id)
-                ps, pe = self._get_gop_bounds(prev_end, prev_img, 0)
+                ps, pe = self._get_gop_bounds(prev_end, gop_size)
                 ranges.append((ps, pe))
                 prev_end = ps - 1
 
@@ -981,8 +933,7 @@ class DataFileExtended(DataFile):
             for _ in range(gop_count):
                 if next_start >= total:
                     break
-                next_img = self.table_image.get(sort_index=next_start, layer_id=layer.id)
-                ns, ne = self._get_gop_bounds(next_start, next_img, 0)
+                ns, ne = self._get_gop_bounds(next_start, gop_size)
                 ranges.append((ns, ne))
                 next_start = ne + 1
 

--- a/clickpoints/modules/OptionEditor.py
+++ b/clickpoints/modules/OptionEditor.py
@@ -301,19 +301,20 @@ class OptionEditorWindow(QtWidgets.QWidget):
                 if option.hidden:
                     continue
                 edit = getOptionInputWidget(option, self.layout)
-                edit.valueChanged.connect(lambda value, edit=edit, option=option: self.Changed(edit, value, option))
+                if option.key in {"bidirectional_preloading", "preload_mode"}:
+                    edit.valueChanged.connect(
+                        lambda value, edit=edit, option=option: self._preload_option_changed(edit, value, option)
+                    )
+                else:
+                    edit.valueChanged.connect(
+                        lambda value, edit=edit, option=option: self.Changed(edit, value, option)
+                    )
                 edit.current_value = None
                 edit.option = option
                 edit.error = None
                 edit.has_error = False
                 self.edits.append(edit)
                 self.edits_by_name[option.key] = edit
-                if option.key == "preload_gops":
-                    warning = QtWidgets.QLabel("Warning, GOP couldn't be detected, use image mode instead")
-                    warning.setStyleSheet("color: orange")
-                    warning.hide()
-                    self.gop_warning = warning
-                    self.layout.addWidget(warning)
             self.layout.addStretch()
 
         self.edits_by_name["buffer_size"].setDisabled(options.buffer_mode != 1)
@@ -330,16 +331,20 @@ class OptionEditorWindow(QtWidgets.QWidget):
         on = self.edits_by_name["bidirectional_preloading"].current_value
         if on is None:
             on = opts.bidirectional_preloading
-        mode = self.edits_by_name["preload_mode"].current_value
+        mode_edit = self.edits_by_name["preload_mode"]
+        mode = mode_edit.current_value
         if mode is None:
             mode = opts.preload_mode
-        has_gop = self.data_file.has_gop_info()
+            if on:
+                default = 0 if self.data_file.is_video() else 1
+                mode_edit.setValue(default)
+                mode_edit.current_value = default
+                mode = default
         self.edits_by_name["preload_mode"].setDisabled(not on)
-        self.edits_by_name["preload_gops"].setDisabled(not (on and mode == 0 and has_gop))
+        self.edits_by_name["preload_gops"].setDisabled(not (on and mode == 0))
+        self.edits_by_name["preload_gop_size"].setDisabled(not (on and mode == 0))
         self.edits_by_name["preload_frame_buffer"].setDisabled(not (on and mode == 1))
         self.edits_by_name["preload_batch_size"].setDisabled(not (on and mode == 1))
-        if hasattr(self, "gop_warning"):
-            self.gop_warning.setVisible(on and mode == 0 and not has_gop)
 
     def list_selected(self) -> None:
         pass
@@ -492,10 +497,12 @@ class OptionEditorWindow(QtWidgets.QWidget):
         if option.key == "buffer_mode":
             self.edits_by_name["buffer_size"].setDisabled(value != 1)
             self.edits_by_name["buffer_memory"].setDisabled(value != 2)
-        if option.key in {"bidirectional_preloading", "preload_mode"}:
-            self._update_preload_widgets()
         field.current_value = value
         self.button_apply.setDisabled(False)
+
+    def _preload_option_changed(self, field: QtWidgets.QWidget, value: Any, option: Option) -> None:
+        self.Changed(field, value, option)
+        self._update_preload_widgets()
 
     def Apply(self) -> bool:
         for edit in self.edits:
@@ -511,6 +518,7 @@ class OptionEditorWindow(QtWidgets.QWidget):
         self.data_file.optionsChanged(None)
         BroadCastEvent(self.window.modules, "optionsChanged", None)
         self.window.JumpFrames(0)
+        self._update_preload_widgets()
         return True
 
     def Ok(self) -> None:


### PR DESCRIPTION
## Summary
- add `preload_gop_size` option so users can set GOP length for video preloading
- default preload mode to match whether the data source is a video and enable GOP controls accordingly
- compute GOP ranges using the user-provided size instead of automatic detection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689793021170832e941fc526d724dd63