### PR TITLE
Fix missing table error in threads by sharing in-memory SQLite

### DIFF
--- a/clickpoints/includes/Database.py
+++ b/clickpoints/includes/Database.py
@@ -148,7 +148,10 @@ def SQLMemoryDBFromFile(filename: str, *args, **kwargs):
         tempfile.write('%s\n' % line)
     tempfile.seek(0)
 
-    db_memory = peewee.SqliteDatabase(":memory:", *args, **kwargs)
+    import uuid
+    memory_name = f"file:{uuid.uuid4().hex}?mode=memory&cache=shared"
+    db_memory = peewee.SqliteDatabase(memory_name, uri=True, *args, **kwargs)
+    db_memory.connect()
     db_memory.connection().cursor().executescript(tempfile.read())
     db_memory.connection().commit()
     return db_memory

--- a/tests/Test_SQLMemoryDB.py
+++ b/tests/Test_SQLMemoryDB.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import threading
+import unittest
+
+import peewee
+
+from clickpoints.includes.Database import SQLMemoryDBFromFile
+
+
+class Test_SQLMemoryDB(unittest.TestCase):
+
+    def test_shared_memory_db_across_threads(self):
+        fd, filename = None, "shared_test.db"
+        try:
+            db = peewee.SqliteDatabase(filename)
+
+            class BaseModel(peewee.Model):
+                class Meta:
+                    database = db
+
+            class Image(BaseModel):
+                name = peewee.CharField()
+
+            db.connect()
+            db.create_tables([Image])
+            Image.create(name="foo")
+            db.close()
+
+            mem_db = SQLMemoryDBFromFile(filename)
+
+            cur = mem_db.execute_sql("SELECT name FROM image")
+            self.assertEqual(cur.fetchone()[0], "foo")
+
+            result = []
+
+            def worker():
+                cur = mem_db.execute_sql("SELECT name FROM image")
+                result.append(cur.fetchone()[0])
+
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join()
+
+            self.assertEqual(result, ["foo"])
+            mem_db.close()
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- ensure in-memory SQLite database is opened using a shared cache so worker threads see the same tables
- add regression test exercising access to shared in-memory DB from multiple threads

## Testing
- `python tests/Test_SQLMemoryDB.py -q` *(fails: ModuleNotFoundError: No module named 'peewee')*


------
https://chatgpt.com/codex/tasks/task_e_689864bb8464832e991d6b3c5ffe306d