### PR TITLE
Fix missing table error and add GOP-aware bidirectional preloading

### DIFF
--- a/clickpoints/Core.py
+++ b/clickpoints/Core.py
@@ -378,13 +378,11 @@ class ClickPointsWindow(QtWidgets.QWidget):
 
         opts = self.data_file.getOptionAccess()
         if opts.bidirectional_preloading:
-            radius = opts.preload_radius
-            gop_default = opts.preload_default_gop
             # schedule quickly so UI isn't blocked
             QtCore.QTimer.singleShot(
                 0,
-                lambda r=radius, g=gop_default, idx=target_id, layer=layer_id: 
-                    self.data_file.preload_bidirectional(idx, layer, r, g)
+                lambda idx=target_id, layer=layer_id, o=opts:
+                    self.data_file.preload_bidirectional(idx, layer, o)
             )
 
 

--- a/clickpoints/DataFile.py
+++ b/clickpoints/DataFile.py
@@ -1614,20 +1614,28 @@ class DataFile:
                     "For videos, whole GOPs around the current frame are preloaded."
         )
         self._AddOption(
+            key="preload_mode",
+            display_name="Preload mode",
+            default=0,
+            value_type="choice",
+            values=["Image", "Video"],
+            tooltip="Select whether preloading is done by frames (image) or by GOPs (video)."
+        )
+        self._AddOption(
             key="preload_radius",
             display_name="Preload radius (frames)",
             default=30,
             value_type="int",
             min_value=1,
-            tooltip="How many frames to preload on each side when bidirectional preloading is enabled."
+            tooltip="How many frames to preload on each side when bidirectional preloading is enabled in image mode."
         )
         self._AddOption(
-            key="preload_default_gop",
-            display_name="Default GOP size (video)",
-            default=60,
+            key="preload_gop_count",
+            display_name="Preload radius (GOPs)",
+            default=1,
             value_type="int",
             min_value=1,
-            tooltip="Fallback GOP size if it cannot be detected from the video file."
+            tooltip="How many GOPs to preload on each side when bidirectional preloading is enabled in video mode."
         )
 
 	

--- a/clickpoints/__init__.py
+++ b/clickpoints/__init__.py
@@ -21,7 +21,10 @@
 
 import importlib.metadata
 
-__version__ = importlib.metadata.metadata('clickpoints')['version']
+try:
+    __version__ = importlib.metadata.metadata('clickpoints')['version']
+except importlib.metadata.PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"
 
 # Try to import the addon library, but for only working with the database, we don't need the Addon
 # definition which is based on Qt

--- a/clickpoints/includes/Database.py
+++ b/clickpoints/includes/Database.py
@@ -34,6 +34,74 @@ import numpy as np
 import peewee
 from qtpy import QtCore
 from qtpy import QtGui
+import json
+import subprocess
+import shlex
+from fractions import Fraction
+
+
+def _probe_stream_fps_and_duration(path: str) -> Tuple[float, Optional[float]]:
+    cmd = (
+        f'ffprobe -v error -select_streams v:0 -show_streams -show_format -of json {shlex.quote(path)}'
+    )
+    data = json.loads(subprocess.check_output(cmd, shell=True, text=True))
+    st = data["streams"][0]
+    afr = st.get("avg_frame_rate", "0/1")
+    num, den = (int(x) for x in afr.split("/"))
+    fps = float(Fraction(num, den)) if den else 0.0
+    dur = None
+    if "format" in data and "duration" in data["format"]:
+        try:
+            dur = float(data["format"]["duration"])
+        except Exception:
+            pass
+    return fps, dur
+
+
+def _first_two_keyframe_times_adaptive(
+    path: str, start_window_s: float = 2.0, max_window_s: float = 120.0
+) -> List[float]:
+    fps, dur = _probe_stream_fps_and_duration(path)
+    t = start_window_s
+    while True:
+        if dur is not None:
+            t = min(t, dur)
+        cmd = (
+            f'ffprobe -v error -skip_frame nokey -select_streams v:0 -show_frames '
+            f'-show_entries frame=pkt_dts_time,pkt_pts_time,best_effort_timestamp_time '
+            f'-read_intervals 0%+{t} -of json {shlex.quote(path)}'
+        )
+        data = json.loads(subprocess.check_output(cmd, shell=True, text=True))
+        times = []
+        for f in data.get("frames", []):
+            for k in (
+                "pkt_dts_time",
+                "pkt_pts_time",
+                "best_effort_timestamp_time",
+            ):
+                v = f.get(k)
+                if v not in (None, "N/A"):
+                    times.append(float(v))
+                    break
+            if len(times) >= 2:
+                break
+        if len(times) >= 2 or (dur is not None and t >= dur) or t >= max_window_s:
+            return times
+        t *= 2
+
+
+def _probe_const_gop(path: str) -> Tuple[float, int, float]:
+    fps, dur = _probe_stream_fps_and_duration(path)
+    if fps <= 0:
+        fps = 30.0
+    kft = _first_two_keyframe_times_adaptive(path)
+    if len(kft) >= 2:
+        gop_dur = max(0.0, kft[1] - kft[0])
+        gop_len = (
+            max(1, int(round(gop_dur * fps))) if gop_dur > 0 else max(1, int(round(fps)))
+        )
+        return fps, gop_len, kft[0]
+    return fps, max(1, int(round(fps))), (kft[0] if kft else 0.0)
 
 from clickpoints.DataFile import DataFile
 from clickpoints.includes.ConfigLoad import dotdict
@@ -148,7 +216,10 @@ def SQLMemoryDBFromFile(filename: str, *args, **kwargs):
         tempfile.write('%s\n' % line)
     tempfile.seek(0)
 
-    db_memory = peewee.SqliteDatabase(":memory:", *args, **kwargs)
+    import uuid
+    memory_name = f"file:{uuid.uuid4().hex}?mode=memory&cache=shared"
+    db_memory = peewee.SqliteDatabase(memory_name, uri=True, *args, **kwargs)
+    db_memory.connect()
     db_memory.connection().cursor().executescript(tempfile.read())
     db_memory.connection().commit()
     return db_memory
@@ -869,89 +940,51 @@ class DataFileExtended(DataFile):
     def _is_video_image(self, image_obj) -> bool:
         fn = image_obj.filename.lower()
         return fn.endswith((".mp4", ".mov", ".avi", ".mkv", ".webm"))
-
-    def _get_gop_bounds(self, frame_index: int, image_obj, default_gop: int) -> Tuple[int, int]:
-        """
-        Return (start, end) indices (inclusive) of the GOP containing frame_index.
-        Try to detect keyframes via imageio metadata; fallback to default_gop.
-        """
-        # simple cache on the DataFileExtended instance
+    def _detect_gop_info(self, image_obj):
         if not hasattr(self, "_gop_cache"):
-            self._gop_cache = {}  # {filename: {"keys":[...], "gop_size":int}}
-
+            self._gop_cache = {}
         fn = image_obj.get_full_filename()
-        cache = self._gop_cache.get(fn)
-        if cache is None:
-            keys = []
-            gop_size = default_gop
+        info = self._gop_cache.get(fn)
+        if info is None:
             try:
-                rdr = imageio.get_reader(fn)
-                md = rdr.get_meta_data()
-                # some backends expose 'key_frames'
-                keys = md.get("key_frames", []) or md.get("keyframes", [])
-                if not keys and "codec" in md:
-                    # no real data; keep default
-                    pass
-                if keys:
-                    # derive variable GOP, but we still preload full blocks around current
-                    pass
+                fps, gop_len, first_kf_time = _probe_const_gop(fn)
+                first_kf_frame = int(round(first_kf_time * fps))
+                info = (gop_len, first_kf_frame)
             except Exception:
-                pass
-            cache = {"keys": keys, "gop_size": gop_size}
-            self._gop_cache[fn] = cache
+                info = None
+            self._gop_cache[fn] = info
+        return info
 
-        keys = cache["keys"]
-        gop_size = cache["gop_size"]
-
-        if keys:
-            # find last key <= frame_index
-            import bisect
-            i = bisect.bisect_right(keys, frame_index) - 1
-            start = keys[i] if i >= 0 else 0
-            # next key - 1 or end of video
-            end = keys[i + 1] - 1 if i + 1 < len(keys) else self.get_image_count() - 1
-            return start, end
-        else:
-            # fixed-size GOP fallback
-            start = (frame_index // gop_size) * gop_size
-            end = min(start + gop_size - 1, self.get_image_count() - 1)
-            return start, end
-
-    def preload_bidirectional(self, center: int, layer, n: int, default_gop: int):
-        """Preload +/- n frames for images, or whole GOPs for videos."""
+    def preload_bidirectional(self, center: int, layer, opts):
+        """Preload frames or GOPs around center based on options."""
         if center is None:
             return
-        # get current image object
         img = self.table_image.get(sort_index=center, layer_id=layer.id)
+        total = self.get_image_count()
 
-        if self._is_video_image(img):
-            # preload previous, current, next GOPs around center (enough to cover +/- n)
-            cur_start, cur_end = self._get_gop_bounds(center, img, default_gop)
-            ranges = [(cur_start, cur_end)]
-
-            # previous needed?
-            if center - n < cur_start:
-                prev_start = max(cur_start - default_gop, 0)
-                # if we have keys, recompute
-                ps, pe = self._get_gop_bounds(prev_start, img, default_gop)
-                ranges.append((ps, pe))
-
-            # next needed?
-            if center + n > cur_end:
-                ns = cur_end + 1
-                if ns < self.get_image_count():
-                    ns, ne = self._get_gop_bounds(ns, img, default_gop)
-                    ranges.append((ns, ne))
-
-            frames = []
-            for s, e in ranges:
-                frames.extend(range(s, e + 1))
+        frames: List[int] = []
+        if opts.preload_mode == 1 and self._is_video_image(img):
+            info = self._detect_gop_info(img)
+            if info is not None:
+                gop_len, first_kf = info
+                g = (center - first_kf) // gop_len
+                for offset in range(-opts.preload_gop_count, opts.preload_gop_count + 1):
+                    start = first_kf + (g + offset) * gop_len
+                    if start < 0 or start >= total:
+                        continue
+                    end = min(start + gop_len - 1, total - 1)
+                    frames.extend(range(start, end + 1))
+            else:
+                radius = opts.preload_radius
+                start = max(center - radius, 0)
+                end = min(center + radius, total - 1)
+                frames = range(start, end + 1)
         else:
-            # still images
-            start = max(center - n, 0)
-            end = min(center + n, self.get_image_count() - 1)
+            radius = opts.preload_radius
+            start = max(center - radius, 0)
+            end = min(center + radius, total - 1)
             frames = range(start, end + 1)
-        # schedule buffering in a background worker to avoid blocking the UI
+
         task = self._PreloadTask(self, frames, layer)
         self.preload_pool.start(task)
 

--- a/clickpoints/modules/OptionEditor.py
+++ b/clickpoints/modules/OptionEditor.py
@@ -313,8 +313,13 @@ class OptionEditorWindow(QtWidgets.QWidget):
         self.edits_by_name["buffer_size"].setDisabled(options.buffer_mode != 1)
         self.edits_by_name["buffer_memory"].setDisabled(options.buffer_mode != 2)
         opts = options
-        self.edits_by_name["preload_radius"].setDisabled(not opts.bidirectional_preloading)
-        self.edits_by_name["preload_default_gop"].setDisabled(not opts.bidirectional_preloading)
+        self.edits_by_name["preload_mode"].setDisabled(not opts.bidirectional_preloading)
+        self.edits_by_name["preload_radius"].setDisabled(
+            not opts.bidirectional_preloading or opts.preload_mode != 0
+        )
+        self.edits_by_name["preload_gop_count"].setDisabled(
+            not opts.bidirectional_preloading or opts.preload_mode != 1
+        )
 
     def updateEditField(self, edit: QtWidgets.QWidget, value: Any, option: Option) -> None:
         print(option.value_type, value, edit)
@@ -474,8 +479,14 @@ class OptionEditorWindow(QtWidgets.QWidget):
             self.edits_by_name["buffer_memory"].setDisabled(value != 2)
         if option.key == "bidirectional_preloading":
             # toggle related fields
-            self.edits_by_name["preload_radius"].setDisabled(not value)
-            self.edits_by_name["preload_default_gop"].setDisabled(not value)
+            self.edits_by_name["preload_mode"].setDisabled(not value)
+            mode = self.edits_by_name["preload_mode"].value()
+            self.edits_by_name["preload_radius"].setDisabled(not value or mode != 0)
+            self.edits_by_name["preload_gop_count"].setDisabled(not value or mode != 1)
+        if option.key == "preload_mode":
+            bidir = self.edits_by_name["bidirectional_preloading"].value()
+            self.edits_by_name["preload_radius"].setDisabled(not bidir or value != 0)
+            self.edits_by_name["preload_gop_count"].setDisabled(not bidir or value != 1)
         field.current_value = value
         self.button_apply.setDisabled(False)
 

--- a/tests/Test_GOPDetection.py
+++ b/tests/Test_GOPDetection.py
@@ -1,0 +1,29 @@
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from clickpoints.includes.Database import _probe_const_gop
+
+
+class TestGOPDetection(unittest.TestCase):
+    def test_probe_const_gop(self):
+        try:
+            subprocess.check_call(
+                "ffmpeg -y -f lavfi -i testsrc=size=16x16:rate=30 -frames:v 30 -g 10 gop_test.mp4",
+                shell=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except FileNotFoundError:
+            self.skipTest("ffmpeg not installed")
+        fps, gop_len, _ = _probe_const_gop("gop_test.mp4")
+        self.assertEqual(gop_len, 10)
+        os.remove("gop_test.mp4")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/Test_SQLMemoryDB.py
+++ b/tests/Test_SQLMemoryDB.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import threading
+import unittest
+
+import peewee
+
+from clickpoints.includes.Database import SQLMemoryDBFromFile
+
+
+class Test_SQLMemoryDB(unittest.TestCase):
+
+    def test_shared_memory_db_across_threads(self):
+        fd, filename = None, "shared_test.db"
+        try:
+            db = peewee.SqliteDatabase(filename)
+
+            class BaseModel(peewee.Model):
+                class Meta:
+                    database = db
+
+            class Image(BaseModel):
+                name = peewee.CharField()
+
+            db.connect()
+            db.create_tables([Image])
+            Image.create(name="foo")
+            db.close()
+
+            mem_db = SQLMemoryDBFromFile(filename)
+
+            cur = mem_db.execute_sql("SELECT name FROM image")
+            self.assertEqual(cur.fetchone()[0], "foo")
+
+            result = []
+
+            def worker():
+                cur = mem_db.execute_sql("SELECT name FROM image")
+                result.append(cur.fetchone()[0])
+
+            t = threading.Thread(target=worker)
+            t.start()
+            t.join()
+
+            self.assertEqual(result, ["foo"])
+            mem_db.close()
+        finally:
+            if os.path.exists(filename):
+                os.remove(filename)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- share in-memory SQLite database across threads to avoid missing table errors
- add GOP-aware bidirectional preloading with selectable video/image modes and dynamic option availability
- include ffprobe-based GOP detection and regression test for constant GOPs

## Testing
- `python tests/Test_SQLMemoryDB.py -q` *(fails: ModuleNotFoundError: No module named 'peewee')*
- `python tests/Test_GOPDetection.py -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689864bb8464832e991d6b3c5ffe306d