### PR TITLE
Handle buffer automatically for bidirectional preloading

### DIFF
--- a/clickpoints/includes/Database.py
+++ b/clickpoints/includes/Database.py
@@ -854,17 +854,28 @@ class DataFileExtended(DataFile):
             self.buffer_frame(image_obj, image_obj.get_full_filename(), slots, slot_index, idx, layer=layer)
 
     class _PreloadTask(QtCore.QRunnable):
-        """Worker that preloads frames without blocking the main thread."""
+        """Worker that preloads frames and prunes the buffer in the background."""
 
-        def __init__(self, datafile, frames, layer):
+        def __init__(self, datafile, frames, layer, keep_indices=None):
             super().__init__()
             # materialize indices so they can be reused inside the worker
             self.datafile = datafile
             self.frames = list(frames)
             self.layer = layer
+            self.keep = set(keep_indices or [])
 
         def run(self):
+            # preload required frames
             self.datafile.ensure_frames_buffered(self.frames, self.layer)
+            # remove frames outside the keep range to free memory
+            if self.keep:
+                buf = self.datafile.buffer
+                # copy to avoid issues if buffer changes during iteration
+                for number, layer_id in list(buf.indices):
+                    if number is None or layer_id != self.layer.id:
+                        continue
+                    if number not in self.keep:
+                        buf.remove_frame(number, self.layer)
     
     def _is_video_image(self, image_obj) -> bool:
         fn = image_obj.filename.lower()
@@ -932,7 +943,6 @@ class DataFileExtended(DataFile):
             # previous needed?
             if center - n < cur_start:
                 prev_start = max(cur_start - default_gop, 0)
-                # if we have keys, recompute
                 ps, pe = self._get_gop_bounds(prev_start, img, default_gop)
                 ranges.append((ps, pe))
 
@@ -950,9 +960,26 @@ class DataFileExtended(DataFile):
             # still images
             start = max(center - n, 0)
             end = min(center + n, self.get_image_count() - 1)
-            frames = range(start, end + 1)
-        # schedule buffering in a background worker to avoid blocking the UI
-        task = self._PreloadTask(self, frames, layer)
+            frames = list(range(start, end + 1))
+
+        # determine frames we want to keep in the buffer (preloaded frames plus
+        # some margin on both sides). Keeping more frames than strictly
+        # necessary avoids stuttering when quickly scrubbing through frames.
+        if frames:
+            keep_start = max(min(frames) - n, 0)
+            keep_end = min(max(frames) + n, self.get_image_count() - 1)
+            keep_indices = range(keep_start, keep_end + 1)
+            # make sure the internal buffer can hold the desired amount of frames
+            needed = len(list(keep_indices)) + 5  # little extra margin
+            if self.buffer.buffer_mode != 1 or self.buffer.buffer_count < needed:
+                # switch to frame-count based buffer with sufficient slots
+                self.buffer.setBufferCount(needed, 0, 1)
+        else:
+            keep_indices = []
+
+        # schedule buffering and pruning in a background worker to avoid
+        # blocking the UI
+        task = self._PreloadTask(self, frames, layer, keep_indices)
         self.preload_pool.start(task)
 
 

--- a/clickpoints/modules/OptionEditor.py
+++ b/clickpoints/modules/OptionEditor.py
@@ -310,9 +310,16 @@ class OptionEditorWindow(QtWidgets.QWidget):
                 self.edits_by_name[option.key] = edit
             self.layout.addStretch()
 
-        self.edits_by_name["buffer_size"].setDisabled(options.buffer_mode != 1)
-        self.edits_by_name["buffer_memory"].setDisabled(options.buffer_mode != 2)
         opts = options
+        # If bidirectional preloading is active the buffer is managed
+        # internally and all manual buffer controls should be disabled.
+        self.edits_by_name["buffer_mode"].setDisabled(opts.bidirectional_preloading)
+        self.edits_by_name["buffer_size"].setDisabled(
+            opts.bidirectional_preloading or options.buffer_mode != 1
+        )
+        self.edits_by_name["buffer_memory"].setDisabled(
+            opts.bidirectional_preloading or options.buffer_mode != 2
+        )
         self.edits_by_name["preload_radius"].setDisabled(not opts.bidirectional_preloading)
         self.edits_by_name["preload_default_gop"].setDisabled(not opts.bidirectional_preloading)
 
@@ -470,12 +477,24 @@ class OptionEditorWindow(QtWidgets.QWidget):
                                 "Estimated memory usage:<br/>%s" % PrittyPrintSize(value * self.window.im.nbytes),
                                 width=140, normal_msg=True)
         if option.key == "buffer_mode":
-            self.edits_by_name["buffer_size"].setDisabled(value != 1)
-            self.edits_by_name["buffer_memory"].setDisabled(value != 2)
+            # when bidirectional preloading is inactive, mode determines which
+            # of the size/memory fields is editable
+            self.edits_by_name["buffer_size"].setDisabled(
+                value != 1 or self.edits_by_name["buffer_mode"].isEnabled() is False
+            )
+            self.edits_by_name["buffer_memory"].setDisabled(
+                value != 2 or self.edits_by_name["buffer_mode"].isEnabled() is False
+            )
         if option.key == "bidirectional_preloading":
-            # toggle related fields
+            # toggle related fields and buffer controls
             self.edits_by_name["preload_radius"].setDisabled(not value)
             self.edits_by_name["preload_default_gop"].setDisabled(not value)
+            self.edits_by_name["buffer_mode"].setDisabled(value)
+            mode_val = self.edits_by_name["buffer_mode"].current_value
+            if mode_val is None:
+                mode_val = self.data_file.getOption("buffer_mode")
+            self.edits_by_name["buffer_size"].setDisabled(value or mode_val != 1)
+            self.edits_by_name["buffer_memory"].setDisabled(value or mode_val != 2)
         field.current_value = value
         self.button_apply.setDisabled(False)
 


### PR DESCRIPTION
## Summary
- Disable manual buffer controls when bidirectional preloading is enabled
- Preload worker now frees frames outside a padded window
- Automatically size buffer for bidirectional preloading

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898e9366d58832ea2c0abf14638895b